### PR TITLE
[002][Bugfix] Announcements in Announcement Page is now ordered by creation date

### DIFF
--- a/api/app/Http/Controllers/AnnouncementController.php
+++ b/api/app/Http/Controllers/AnnouncementController.php
@@ -18,7 +18,7 @@ class AnnouncementController extends Controller
 
     public function channelAnnouncements(Request $request)
     {
-        $announcements = Announcement::with('user')->channel($request)->get();
+        $announcements = Announcement::with('user')->channel($request)->orderBy('created_at')->get();
 
         return response()->json($announcements);
     }


### PR DESCRIPTION
## Asana Link
https://app.asana.com/0/1203002524654351/1203204651447787/f

## Commands
<!-- commands to run in order to test PR -->
- [ ] in the terminal, go to the project directory and cd into api directory - `cd api`
- [ ] run `php artisan serve`

- [ ] in the terminal, go to the project directory and cd into api directory - `cd client`
- [ ] run `npm start`

## Expected Output
<!-- insert expected behavior of application with the new changes applied --> 
- [ ] The list of announcements in the announcement page is now ordered according to `created_at` attribute
- [ ] Editing an announcement will now not alter their displayed order

## Screenshots
<!-- for FE - insert screenshots of components or markups on pages here -->
![image](https://user-images.githubusercontent.com/111718037/197469572-2bf27c0d-7fbb-4104-8933-1ab5841529c4.png)

<!-- for BE - insert screenshots of API test results done in Postman or Insomnia here-->
