### PR TITLE
[049][BE] Created lock functionality for announcements

### DIFF
--- a/api/app/Http/Controllers/AnnouncementController.php
+++ b/api/app/Http/Controllers/AnnouncementController.php
@@ -149,4 +149,34 @@ class AnnouncementController extends Controller
             ]);
         }
     }
+
+    public function lock(Request $request, $id)
+    {
+        $user = Auth::user();
+
+        $user_fullname = $user['fullname'];
+        $user_role_id = $user->roleUser->role_id;
+
+        //checks if role_user has permission canUpdateAnnouncement
+        $canUpdateAnnouncement = PermissionRole::where('role_id', $user_role_id)
+            ->whereHas('permission', function ($query) {
+                $query->where('permission', 'canUpdateAnnouncement');
+            })->exists();
+
+        //checks if user with role has canCreateAnnouncement permission
+        if ($canUpdateAnnouncement) {
+            $announcement = Announcement::find($id);
+            $locked = $announcement->update(['is_locked' => ! $announcement['is_locked']]);
+
+            $data = [
+                'message' => "Successfully" . ($announcement['is_locked'] ? " locked ":" unlocked ")  . "announcement!",
+                'user' => $user_fullname,
+            ];
+            return response()->json($data);
+        } else {
+            return response()->json([
+                'message' => $user_fullname . ' does not have permission to update announcement.'
+            ]);
+        }
+    }
 }

--- a/api/app/Models/Announcement.php
+++ b/api/app/Models/Announcement.php
@@ -13,7 +13,8 @@ class Announcement extends Model
         'announcementable_id',
         'announcementable_type',
         'user_id',
-        'announcement'
+        'announcement',
+        'is_locked'
     ];
 
     public function announcementable() {

--- a/api/database/migrations/2022_10_25_031021_add_is_locked_column_to_announcements_table.php
+++ b/api/database/migrations/2022_10_25_031021_add_is_locked_column_to_announcements_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('announcements', function (Blueprint $table) {
+            //
+            $table->boolean('is_locked')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('announcements', function (Blueprint $table) {
+            //
+            $table->dropColumn('is_locked');
+        });
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -30,6 +30,7 @@ Route::middleware('auth:sanctum', 'throttle:100,1')->group(function () {
     Route::apiResource('/role', RoleController::class);
     Route::apiResource('/department', DepartmentController::class);
     Route::apiResource('/announcement', AnnouncementController::class);
+    Route::put('/announcement/{id}/lock', [AnnouncementController::class, 'lock']);
     Route::get('/announcements', [AnnouncementController::class, 'channelAnnouncements']);
     Route::apiResource('/college', CollegeController::class);
     Route::apiResource('/course', CourseController::class);


### PR DESCRIPTION
## Asana Link
<!-- insert Asana link here -->
https://app.asana.com/0/1203011106874563/1203087509751323/f


## Commands
<!-- commands to run in order to test PR -->
- [ ] in the terminal, go to the project directory and cd into api directory - `cd api`
- [ ] run `php artisan migrate`
- [ ] run `php artisan serve`
- [ ] to lock/unlock threads for an announcement, send PUT request to `localhost:8000/api/announcement/{id}/lock`

## Expected Output
<!-- insert expected behavior of application with the new changes applied --> 
- [ ] each PUT request will toggle the `is_locked` property of the announcement

## Screenshots
<!-- for FE - insert screenshots of components or markups on pages here -->
<!-- for BE - insert screenshots of API test results done in Postman or Insomnia here-->
![image](https://user-images.githubusercontent.com/111718037/197697561-c5b3a621-e722-4bd7-b7c0-a8fcbff03020.png)
![image](https://user-images.githubusercontent.com/111718037/197697630-6ae7215b-e527-497c-99b7-903fb67a4f99.png)

