### PR TITLE
[091][Bugfix] Stop searching if keyword is empty in ManageUsersPage search input

### DIFF
--- a/api/app/Http/Controllers/UserController.php
+++ b/api/app/Http/Controllers/UserController.php
@@ -43,7 +43,7 @@ class UserController extends Controller
                 ->orderBy($request->order_name, $request->order_direction)
                 ->paginate($request->items_per_page);
 
-                return response()->json($users);
+                return response()->json($selectUsers);
             }
 
         $selectUsers = User::with(['roleUser.role', 'department'])->where('university_id', $request->university_id)

--- a/client/src/pages/ManageUsersPage.js
+++ b/client/src/pages/ManageUsersPage.js
@@ -16,10 +16,10 @@ const ManageUsersPage = () => {
   });
 
   const handleSearch = (e) => {
-    if (e.target.value === '' ) {
+    if ((params.keyword !== '') && e.target.value === '' ) {
       setParams({...params, page: 1, keyword: ''})
     }
-
+      
     if (e.key === 'Enter') {
       setParams({...params, keyword: searchKeyword, page: 1})
     }


### PR DESCRIPTION
## Asana Link
<!-- insert Asana link here -->
https://app.asana.com/0/1203011106874563/1203318449682623

## Pre-requisite
<!-- setup needed in order to test the changes applied -->
- [ ] Sample users must be available in order to use search functionality

## Commands
<!-- commands to run in order to test PR -->
- [ ] in the terminal, go to the project directory and cd into api directory - `cd client`
- [ ] run `npm start`

## Expected Output
<!-- insert expected behavior of application with the new changes applied --> 
- [ ] Open the Chrome dev-tools and go to Network tab
- [ ] Test searching for a user. The search functionality should be working back to normal.
- [ ] Empty the search input and keep on pressing backspace on the keyboard. There should only be one (1) request sent in the network tab no matter how many times backspace is pressed. (Previously, it kept sending a request for every press on backspace if the searchbar is empty)
