### PR TITLE
[022][Bugfix] Fixed RichTextEditor special keys and thread character limit

### DIFF
--- a/api/database/migrations/2022_09_26_020522_create_threads_table.php
+++ b/api/database/migrations/2022_09_26_020522_create_threads_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('announcement_id')->nullable()->constrained()->cascadeOnDelete();
-            $table->string('thread_message');
+            $table->longText('thread_message');
             $table->timestamps();
         });
     }

--- a/client/src/components/AnnouncementCard.js
+++ b/client/src/components/AnnouncementCard.js
@@ -86,7 +86,7 @@ export default function AnnouncementCard(props) {
                   />
                 </div>
               ) : (
-                <span className="cardText text-gray-700 text-base">
+                <span className="text-gray-700 text-base ql-editor card">
                   {parse(props.announcement.announcement)}
                 </span>
               )

--- a/client/src/components/ChatCard.js
+++ b/client/src/components/ChatCard.js
@@ -62,7 +62,7 @@ const ChatCard = ({ chat, handleRefresh, setChatId, setShowComments, showComment
               />
             </div>
           ) : (
-            <span className="text-gray-700 text-base">{parse(chat.chat)}</span>
+            <span className="text-gray-700 text-base card ql-editor">{parse(chat.chat)}</span>
           )}
         </div>
 

--- a/client/src/components/CommentCard.js
+++ b/client/src/components/CommentCard.js
@@ -60,7 +60,7 @@ const CommentCard = ({comment, handleRefresh}) => {
                 />
               </div>
             ) : (
-              <span className="text-gray-700 text-sm">
+              <span className="text-gray-700 text-sm ql-editor card">
                 {parse(comment?.comment)}
               </span>
             )}

--- a/client/src/components/CommentsHeader.js
+++ b/client/src/components/CommentsHeader.js
@@ -18,7 +18,7 @@ const CommentsHeader = ({chat}) => {
           </span>
         </div>
         <div>
-          <span className="text-gray-700 text-base">
+          <span className="text-gray-700 text-base ql-editor">
             {parse(String(chat?.chat))}
           </span>
         </div>

--- a/client/src/components/ThreadCard.js
+++ b/client/src/components/ThreadCard.js
@@ -72,7 +72,7 @@ export default function AnnouncementCard(props) {
                 />
               </div>
             ) : (
-              <span className="cardText text-gray-700 text-sm">
+              <span className="text-gray-700 text-sm ql-editor card">
                 {props.thread.announcement ? parse(props.thread.announcement): parse(props.thread.thread_message)}
               </span>
             )}

--- a/client/src/components/ThreadsHeader.js
+++ b/client/src/components/ThreadsHeader.js
@@ -19,7 +19,7 @@ const ThreadsHeader = ({thread}) => {
           </span>
         </div>
         <div>
-          <span className="text-gray-700 text-base">
+          <span className="text-gray-700 text-base ql-editor card">
             {parse(String(thread?.announcement))}
           </span>
         </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -44,18 +44,6 @@
   border-top: 0px;
 }
 
-.cardText ol {
-  list-style-type: decimal;
-}
-
-.cardText ul {
-  list-style-type: disc;
-}
-
-.cardText li {
-  margin-left: 3rem;
-}
-
 h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
 }
@@ -70,4 +58,9 @@ h2 {
 
 h3 {
   font-size: 1.1rem;
+}
+
+.card.ql-editor {
+  min-height: 1rem;
+  padding: 0px 0px;
 }


### PR DESCRIPTION
## Asana Link
<!-- insert Asana link here -->
https://app.asana.com/0/1203002524654351/1203318414342958/f

## Pre-requisite
<!-- setup needed in order to test the changes applied -->
- [ ] create announcements, threads and chats with styles from RichTextEditor.
- [ ] Create thread message that exceed 250 characters


## Commands
<!-- commands to run in order to test PR -->
- [ ] in the terminal, go to the project directory and cd into api directory - `cd api`
- [ ] run `php artisan migrate`
- [ ] run `php artisan serve`

- [ ] in the terminal, go to the project directory and cd into api directory - `cd client`
- [ ] run `npm start`

## Expected Output
<!-- insert expected behavior of application with the new changes applied --> 
- [ ] indentation of ordered and unordered list from RichTextEditor now properly reflect on all announcement and chat cards
- [ ] characters for threads can now exceed 250.

## Screenshots
<!-- for FE - insert screenshots of components or markups on pages here -->
- User Announcement
![image](https://user-images.githubusercontent.com/111718037/201026136-8648f89b-685e-4ba3-917f-39c56e96a28f.png)

- User Class Page
![image](https://user-images.githubusercontent.com/111718037/201025913-71735005-b1c8-4849-8fe8-371573adb046.png)

- Admin Announcement
![image](https://user-images.githubusercontent.com/111718037/201026316-f734aa51-0669-4965-9bf8-fdd1b0cac8c4.png)

- Thread
![image](https://user-images.githubusercontent.com/111718037/201026400-081bd7b7-4741-4340-a3d1-a1ae4b9717f2.png)

- Chat
![image](https://user-images.githubusercontent.com/111718037/201026042-02544a9e-3c28-48eb-b496-110615ed90b2.png)

<!-- for BE - insert screenshots of API test results done in Postman or Insomnia here-->
